### PR TITLE
Change mod name to use title case

### DIFF
--- a/barrel_stages/changelog.txt
+++ b/barrel_stages/changelog.txt
@@ -1,5 +1,13 @@
 ---------------------------------------------------------------------------------------------------
-Version: 0.1.0
+Version: 1.1.1
+Date: 2024.10.30 00:37:30+01:00
+  Changes:
+    - Switched to title case
+    - Added Space Age to optional dependencies in info.json
+    - Fixed changelog versions
+---------------------------------------------------------------------------------------------------
+
+Version: 1.1.0
 Date: 2024.10.21 19:13:46+02:00
   Changes:
     - Upgraded to Factorio 2.0 and Space Age

--- a/barrel_stages/info.json
+++ b/barrel_stages/info.json
@@ -1,10 +1,10 @@
 {
     "name": "barrel-stages",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "title": "Barrel Stages",
     "author": "Tooster",
     "contact": "Tooster#3471",
     "factorio_version": "2.0",
-    "dependencies": ["base >= 2.0"],
+    "dependencies": ["base >= 2.0", "? space-age >=2.0"],
     "description": "Fixes inconsistency with barelling recipes unlocked before unlocking their respective fluids first. Lubricant barrel recipe won't show up before researching lubricant first, and so on. Good for new players — it reduces the sudden overwhelming influx of recipes right after unlocking Fluid Processing."
 }

--- a/barrel_stages/info.json
+++ b/barrel_stages/info.json
@@ -1,7 +1,7 @@
 {
     "name": "barrel-stages",
     "version": "1.1.0",
-    "title": "Barrel stages",
+    "title": "Barrel Stages",
     "author": "Tooster",
     "contact": "Tooster#3471",
     "factorio_version": "2.0",


### PR DESCRIPTION
This PR changes the mod name to use title case ("Barrel Stages" instead of "Barrel stages").